### PR TITLE
Telemetry reporting implemented

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,21 @@
 			<version>3.4</version>
 		</dependency>
 		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-core</artifactId>
+			<version>2.9.8</version>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-annotations</artifactId>
+			<version>2.9.8</version>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>2.9.8</version>
+		</dependency>
+		<dependency>
 			<groupId>com.comodide</groupId>
 			<artifactId>jgraphx</artifactId>
 			<version>4.0.1</version>
@@ -88,7 +103,10 @@
 							json,
 							commons-io,
 							jgraphx,
-							commons-lang3
+							commons-lang3,
+							jackson-core,
+							jackson-annotations,
+							jackson-databind
 						</Embed-Dependency>
 					</instructions>
 				</configuration>

--- a/src/main/java/com/comodide/ComodideConfiguration.java
+++ b/src/main/java/com/comodide/ComodideConfiguration.java
@@ -48,6 +48,8 @@ public class ComodideConfiguration {
 	private static final String USE_TARGET_NAMESPACE_KEY = "use_target_namespace";
 	private static final String MODULE_METADATA_EXTERNAL_KEY = "module_metadata_external";
 	private static final String DELETE_PROPERTY_DECLARATIONS_KEY = "delete_property_declarations";
+	private static final String SEND_TELEMETRY_KEY = "send_telemetry"; 
+	private static final String TELEMETRY_PREFERENCE_CHECKED_KEY = "telemetry_preference_checked"; 
 	
 	// Preference manager and set of preferences for the CoModIDE plugin's instantiation configuration
 	private static final PreferencesManager PREFERENCES_MANAGER = PreferencesManager.getInstance();
@@ -128,5 +130,29 @@ public class ComodideConfiguration {
 	
 	public static void setModuleMetadataExternal(Boolean value) {
 		PREFERENCES.putBoolean(MODULE_METADATA_EXTERNAL_KEY, value);
+	}
+	
+	/**
+	 * Whether to send usage telemetry. 
+	 *
+	 */
+	
+	public static Boolean getSendTelemetry() {
+		return PREFERENCES.getBoolean(SEND_TELEMETRY_KEY, false);
+	}
+	
+	public static void setSendTelemetry(Boolean value) {
+		PREFERENCES.putBoolean(SEND_TELEMETRY_KEY, value);
+	}
+	
+	/**
+	 * Whether the user has been queried for telemetry sending
+	 */
+	public static Boolean getTelemetryPreferenceChecked() {
+		return PREFERENCES.getBoolean(TELEMETRY_PREFERENCE_CHECKED_KEY, false);
+	}
+	
+	public static void setTelemetryPreferenceChecked(Boolean value) {
+		PREFERENCES.putBoolean(TELEMETRY_PREFERENCE_CHECKED_KEY, value);
 	}
 }

--- a/src/main/java/com/comodide/editor/SDTransferHandler.java
+++ b/src/main/java/com/comodide/editor/SDTransferHandler.java
@@ -38,6 +38,7 @@ import org.slf4j.LoggerFactory;
 import com.comodide.ComodideConfiguration;
 import com.comodide.patterns.PatternTransferable;
 import com.comodide.rendering.PositioningOperations;
+import com.comodide.telemetry.TelemetryAgent;
 import com.google.common.base.Optional;
 import com.mxgraph.swing.mxGraphComponent;
 import com.mxgraph.swing.handler.mxGraphTransferHandler;
@@ -247,7 +248,7 @@ public class SDTransferHandler extends mxGraphTransferHandler
 				}
 
 				modelManager.applyChanges(newAxioms);
-
+				TelemetryAgent.logPatternDrop();
 				result = true;
 			}
 			catch (Exception ex)

--- a/src/main/java/com/comodide/patterns/PatternTable.java
+++ b/src/main/java/com/comodide/patterns/PatternTable.java
@@ -84,6 +84,7 @@ public class PatternTable extends JTable {
 				try {
 					OWLOntology selectedPatternOntology = PatternLibrary.getInstance().getOwlRepresentation(selectedPattern);
 					PatternInstantiator pi = new PatternInstantiator(selectedPatternOntology, selectedPattern.getLabel(), modelManager);
+					TelemetryAgent.setLastDraggedPatternName(String.format("Pattern: %s (%s)", selectedPattern.getLabel(), selectedPattern.getIri().toString()));
 					Set<OWLAxiom> instantiationAxioms = pi.getInstantiationAxioms();
 					Set<OWLAxiom> modularizationAxioms = pi.getModuleAnnotationAxioms();
 					return new PatternTransferable(instantiationAxioms, modularizationAxioms);

--- a/src/main/java/com/comodide/patterns/PatternTable.java
+++ b/src/main/java/com/comodide/patterns/PatternTable.java
@@ -102,8 +102,10 @@ public class PatternTable extends JTable {
 		this.getSelectionModel().addListSelectionListener(new ListSelectionListener() {
 			@Override
 			public void valueChanged(ListSelectionEvent e) {
-				Pattern selectedPattern = ((PatternTableModel) dataModel).getPatternAtRow(getSelectedRow());
-				TelemetryAgent.logLibraryClick(String.format("Pattern: %s (%s)", selectedPattern.getLabel(), selectedPattern.getIri().toString()));
+				if (!e.getValueIsAdjusting()) {
+					Pattern selectedPattern = ((PatternTableModel) dataModel).getPatternAtRow(getSelectedRow());
+					TelemetryAgent.logLibraryClick(String.format("Pattern: %s (%s)", selectedPattern.getLabel(), selectedPattern.getIri().toString()));
+				}
 			}
 		});
 	}

--- a/src/main/java/com/comodide/patterns/PatternTable.java
+++ b/src/main/java/com/comodide/patterns/PatternTable.java
@@ -7,7 +7,11 @@ import org.semanticweb.owlapi.model.OWLOntologyCreationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.comodide.telemetry.TelemetryAgent;
+
 import javax.swing.*;
+import javax.swing.event.ListSelectionEvent;
+import javax.swing.event.ListSelectionListener;
 import javax.swing.table.TableCellRenderer;
 import javax.swing.table.TableColumn;
 import java.awt.*;
@@ -94,6 +98,14 @@ public class PatternTable extends JTable {
 		
 		columnModel.getColumn(1).setCellRenderer(new ButtonRenderer());
 		columnModel.getColumn(1).setCellEditor(new ButtonEditor(new JCheckBox()));
+		
+		this.getSelectionModel().addListSelectionListener(new ListSelectionListener() {
+			@Override
+			public void valueChanged(ListSelectionEvent e) {
+				Pattern selectedPattern = ((PatternTableModel) dataModel).getPatternAtRow(getSelectedRow());
+				TelemetryAgent.logLibraryClick(String.format("Pattern: %s (%s)", selectedPattern.getLabel(), selectedPattern.getIri().toString()));
+			}
+		});
 	}
 
 	/**
@@ -160,6 +172,7 @@ public class PatternTable extends JTable {
 		public Object getCellEditorValue() {
 			if (isPushed) {
 				Pattern pattern = ((PatternTableModel) dataModel).getPatternAtRow(getSelectedRow());
+				TelemetryAgent.logLibraryClick(String.format("Documentation: %s (%s)", pattern.getLabel(), pattern.getIri().toString()));
 				PatternDocumentationFrame docFrame = new PatternDocumentationFrame(pattern);
 				docFrame.setVisible(true);
 			}

--- a/src/main/java/com/comodide/patterns/PatternTable.java
+++ b/src/main/java/com/comodide/patterns/PatternTable.java
@@ -102,8 +102,9 @@ public class PatternTable extends JTable {
 		this.getSelectionModel().addListSelectionListener(new ListSelectionListener() {
 			@Override
 			public void valueChanged(ListSelectionEvent e) {
-				if (!e.getValueIsAdjusting()) {
-					Pattern selectedPattern = ((PatternTableModel) dataModel).getPatternAtRow(getSelectedRow());
+				int selectedRow = getSelectedRow();
+				if ((selectedRow != -1) && !e.getValueIsAdjusting()) {
+					Pattern selectedPattern = ((PatternTableModel) dataModel).getPatternAtRow(selectedRow);
 					TelemetryAgent.logLibraryClick(String.format("Pattern: %s (%s)", selectedPattern.getLabel(), selectedPattern.getIri().toString()));
 				}
 			}

--- a/src/main/java/com/comodide/telemetry/ITelemetryMessage.java
+++ b/src/main/java/com/comodide/telemetry/ITelemetryMessage.java
@@ -1,7 +1,0 @@
-package com.comodide.telemetry;
-
-public interface ITelemetryMessage {
-
-	public String getTimestamp();
-	public String getMessage();
-}

--- a/src/main/java/com/comodide/telemetry/ITelemetryMessage.java
+++ b/src/main/java/com/comodide/telemetry/ITelemetryMessage.java
@@ -1,0 +1,7 @@
+package com.comodide.telemetry;
+
+public interface ITelemetryMessage {
+
+	public String getTimestamp();
+	public String getMessage();
+}

--- a/src/main/java/com/comodide/telemetry/TelemetryAgent.java
+++ b/src/main/java/com/comodide/telemetry/TelemetryAgent.java
@@ -1,22 +1,12 @@
 package com.comodide.telemetry;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.OutputStream;
-import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
-import java.net.ProtocolException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class TelemetryAgent {
 
@@ -26,52 +16,16 @@ public class TelemetryAgent {
 	
 	private static List<TelemetryMessage> _loggedMessages = new ArrayList<TelemetryMessage>();
 	
-	public static String SendTelemetry() {
-		
-		ObjectMapper mapper = new ObjectMapper();
-		
-		try {
-			
-			String telemetryMessagesAsJson = mapper.writeValueAsString(_loggedMessages);
-			log.debug("Sending telemetry message: '%s'", telemetryMessagesAsJson);
-			
-			URL url = new URL("http://localhost:5000/telemetry");
-			HttpURLConnection con = (HttpURLConnection) url.openConnection();
-			con.setRequestMethod("POST");
-			
-			con.setRequestProperty("Content-Type", "application/json; utf-8");
-			con.setRequestProperty("Accept", "text/plain");
-			con.setDoOutput(true);
-			
-			try(OutputStream os = con.getOutputStream()) {
-			    byte[] input = telemetryMessagesAsJson.getBytes("utf-8");
-			    os.write(input, 0, input.length);           
-			}
-			
-			try(BufferedReader br = new BufferedReader(new InputStreamReader(con.getInputStream(), "utf-8"))) 
-			{
-				StringBuilder response = new StringBuilder();
-			    String responseLine = null;
-			    while ((responseLine = br.readLine()) != null) {
-			    	response.append(responseLine.trim());
-			    }
-			    
-			    return(response.toString());
-			}
-		} 
-		catch (JsonProcessingException e) {
-			log.error(String.format("JSON processing failed for telemetry list '%s'; exception message: %s", _loggedMessages, e.getLocalizedMessage()));
-		} catch (ProtocolException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		} catch (MalformedURLException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		} catch (IOException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		}
-		return null;
+	public static void SendTelemetry() {
+		ExecutorService executorService = Executors.newSingleThreadExecutor();
+		TelemetryUploader upload = new TelemetryUploader(_loggedMessages);
+		executorService.submit(upload);
+	    executorService.shutdown();
+	}
+	
+	public static void clearLog() 
+	{
+		_loggedMessages.clear();
 	}
 
 	public static void logLibraryClick(String parameter) {
@@ -84,13 +38,13 @@ public class TelemetryAgent {
 		TelemetryMessage newMessage = new TelemetryMessage(_sessionId, "Pattern drop", parameter);
 		_loggedMessages.add(newMessage);
 		log.debug(String.format("Logged pattern drop: %s", parameter));
-		// TODO: send all logged telemetry on separate thread; clear logged messages if successful
+		SendTelemetry();
 	}
 	
 	public static void logTestMessage(String parameter) {
 		TelemetryMessage newMessage = new TelemetryMessage(_sessionId, "TelemetryAgent test method", parameter);
 		_loggedMessages.add(newMessage);
 		log.debug(String.format("Logged test message: %s", parameter));
-		// TODO: send all logged telemetry on separate thread; clear logged messages if successful
+		SendTelemetry();
 	}
 }

--- a/src/main/java/com/comodide/telemetry/TelemetryAgent.java
+++ b/src/main/java/com/comodide/telemetry/TelemetryAgent.java
@@ -16,11 +16,17 @@ public class TelemetryAgent {
 	
 	private static List<TelemetryMessage> _loggedMessages = new ArrayList<TelemetryMessage>();
 	
+	private static String _lastDraggedPatternName;
+	
 	public static void SendTelemetry() {
 		ExecutorService executorService = Executors.newSingleThreadExecutor();
 		TelemetryUploader upload = new TelemetryUploader(_loggedMessages);
 		executorService.submit(upload);
 	    executorService.shutdown();
+	}
+	
+	public static void setLastDraggedPatternName(String patternName) {
+		_lastDraggedPatternName = patternName;
 	}
 	
 	public static void clearLog() 
@@ -34,10 +40,10 @@ public class TelemetryAgent {
 		log.debug(String.format("Logged library click: %s", parameter));
 	}
 	
-	public static void logPatternDrop(String parameter) {
-		TelemetryMessage newMessage = new TelemetryMessage(_sessionId, "Pattern drop", parameter);
+	public static void logPatternDrop() {
+		TelemetryMessage newMessage = new TelemetryMessage(_sessionId, "Pattern drop", _lastDraggedPatternName);
 		_loggedMessages.add(newMessage);
-		log.debug(String.format("Logged pattern drop: %s", parameter));
+		log.debug(String.format("Logged pattern drop: %s", _lastDraggedPatternName));
 		SendTelemetry();
 	}
 	

--- a/src/main/java/com/comodide/telemetry/TelemetryAgent.java
+++ b/src/main/java/com/comodide/telemetry/TelemetryAgent.java
@@ -1,0 +1,68 @@
+package com.comodide.telemetry;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.ProtocolException;
+import java.net.URL;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class TelemetryAgent {
+
+	private static final Logger log = LoggerFactory.getLogger(TelemetryAgent.class);
+	
+	public static String SendTelemetry(ITelemetryMessage message) {
+		
+		ObjectMapper mapper = new ObjectMapper();
+		
+		try {
+			
+			String jsonInputString = mapper.writeValueAsString(message);
+			
+			URL url = new URL("http://localhost:5000/telemetry");
+			HttpURLConnection con = (HttpURLConnection) url.openConnection();
+			con.setRequestMethod("POST");
+			
+			con.setRequestProperty("Content-Type", "application/json; utf-8");
+			con.setRequestProperty("Accept", "text/plain");
+			con.setDoOutput(true);
+			
+			try(OutputStream os = con.getOutputStream()) {
+			    byte[] input = jsonInputString.getBytes("utf-8");
+			    os.write(input, 0, input.length);           
+			}
+			
+			try(BufferedReader br = new BufferedReader(new InputStreamReader(con.getInputStream(), "utf-8"))) 
+			{
+				StringBuilder response = new StringBuilder();
+			    String responseLine = null;
+			    while ((responseLine = br.readLine()) != null) {
+			    	response.append(responseLine.trim());
+			    }
+			    
+			    return(response.toString());
+			}
+		} 
+		catch (JsonProcessingException e) {
+			log.error(String.format("JSON processing failed for object with message %s; exception message: %s", message.getMessage(), e.getLocalizedMessage()));
+		} catch (ProtocolException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		} catch (MalformedURLException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		} catch (IOException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+		return null;
+	}
+}

--- a/src/main/java/com/comodide/telemetry/TelemetryAgent.java
+++ b/src/main/java/com/comodide/telemetry/TelemetryAgent.java
@@ -8,6 +8,8 @@ import java.util.concurrent.Executors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.comodide.ComodideConfiguration;
+
 public class TelemetryAgent {
 
 	public static String _sessionId = UUID.randomUUID().toString();
@@ -33,24 +35,34 @@ public class TelemetryAgent {
 	{
 		_loggedMessages.clear();
 	}
+	
+	private static boolean isTelemetryActive() {
+		return ComodideConfiguration.getSendTelemetry();
+	}
 
 	public static void logLibraryClick(String parameter) {
-		TelemetryMessage newMessage = new TelemetryMessage(_sessionId, "Pattern library click", parameter);
-		_loggedMessages.add(newMessage);
-		log.debug(String.format("Logged library click: %s", parameter));
+		if (isTelemetryActive()) {
+			TelemetryMessage newMessage = new TelemetryMessage(_sessionId, "Pattern library click", parameter);
+			_loggedMessages.add(newMessage);
+			log.debug(String.format("Logged library click: %s", parameter));
+		}
 	}
 	
 	public static void logPatternDrop() {
-		TelemetryMessage newMessage = new TelemetryMessage(_sessionId, "Pattern drop", _lastDraggedPatternName);
-		_loggedMessages.add(newMessage);
-		log.debug(String.format("Logged pattern drop: %s", _lastDraggedPatternName));
-		SendTelemetry();
+		if (isTelemetryActive()) {
+			TelemetryMessage newMessage = new TelemetryMessage(_sessionId, "Pattern drop", _lastDraggedPatternName);
+			_loggedMessages.add(newMessage);
+			log.debug(String.format("Logged pattern drop: %s", _lastDraggedPatternName));
+			SendTelemetry();
+		}
 	}
 	
 	public static void logTestMessage(String parameter) {
-		TelemetryMessage newMessage = new TelemetryMessage(_sessionId, "TelemetryAgent test method", parameter);
-		_loggedMessages.add(newMessage);
-		log.debug(String.format("Logged test message: %s", parameter));
-		SendTelemetry();
+		if (isTelemetryActive()) {
+			TelemetryMessage newMessage = new TelemetryMessage(_sessionId, "TelemetryAgent test method", parameter);
+			_loggedMessages.add(newMessage);
+			log.debug(String.format("Logged test message: %s", parameter));
+			SendTelemetry();
+		}
 	}
 }

--- a/src/main/java/com/comodide/telemetry/TelemetryAgent.java
+++ b/src/main/java/com/comodide/telemetry/TelemetryAgent.java
@@ -8,6 +8,9 @@ import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.ProtocolException;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -17,15 +20,20 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class TelemetryAgent {
 
+	public static String _sessionId = UUID.randomUUID().toString();
+	
 	private static final Logger log = LoggerFactory.getLogger(TelemetryAgent.class);
 	
-	public static String SendTelemetry(ITelemetryMessage message) {
+	private static List<TelemetryMessage> _loggedMessages = new ArrayList<TelemetryMessage>();
+	
+	public static String SendTelemetry() {
 		
 		ObjectMapper mapper = new ObjectMapper();
 		
 		try {
 			
-			String jsonInputString = mapper.writeValueAsString(message);
+			String telemetryMessagesAsJson = mapper.writeValueAsString(_loggedMessages);
+			log.debug("Sending telemetry message: '%s'", telemetryMessagesAsJson);
 			
 			URL url = new URL("http://localhost:5000/telemetry");
 			HttpURLConnection con = (HttpURLConnection) url.openConnection();
@@ -36,7 +44,7 @@ public class TelemetryAgent {
 			con.setDoOutput(true);
 			
 			try(OutputStream os = con.getOutputStream()) {
-			    byte[] input = jsonInputString.getBytes("utf-8");
+			    byte[] input = telemetryMessagesAsJson.getBytes("utf-8");
 			    os.write(input, 0, input.length);           
 			}
 			
@@ -52,7 +60,7 @@ public class TelemetryAgent {
 			}
 		} 
 		catch (JsonProcessingException e) {
-			log.error(String.format("JSON processing failed for object with message %s; exception message: %s", message.getMessage(), e.getLocalizedMessage()));
+			log.error(String.format("JSON processing failed for telemetry list '%s'; exception message: %s", _loggedMessages, e.getLocalizedMessage()));
 		} catch (ProtocolException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
@@ -64,5 +72,25 @@ public class TelemetryAgent {
 			e.printStackTrace();
 		}
 		return null;
+	}
+
+	public static void logLibraryClick(String parameter) {
+		TelemetryMessage newMessage = new TelemetryMessage(_sessionId, "Pattern library click", parameter);
+		_loggedMessages.add(newMessage);
+		log.debug(String.format("Logged library click: %s", parameter));
+	}
+	
+	public static void logPatternDrop(String parameter) {
+		TelemetryMessage newMessage = new TelemetryMessage(_sessionId, "Pattern drop", parameter);
+		_loggedMessages.add(newMessage);
+		log.debug(String.format("Logged pattern drop: %s", parameter));
+		// TODO: send all logged telemetry on separate thread; clear logged messages if successful
+	}
+	
+	public static void logTestMessage(String parameter) {
+		TelemetryMessage newMessage = new TelemetryMessage(_sessionId, "TelemetryAgent test method", parameter);
+		_loggedMessages.add(newMessage);
+		log.debug(String.format("Logged test message: %s", parameter));
+		// TODO: send all logged telemetry on separate thread; clear logged messages if successful
 	}
 }

--- a/src/main/java/com/comodide/telemetry/TelemetryMessage.java
+++ b/src/main/java/com/comodide/telemetry/TelemetryMessage.java
@@ -3,23 +3,34 @@ package com.comodide.telemetry;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
-public class TelemetryMessage implements ITelemetryMessage {
+public class TelemetryMessage {
 	
-	private final SimpleDateFormat _df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
-	private final Date _timestamp;
-	private final String _message;
+	private final String _sessionId;
+	private final String _operation;
+	private final String _parameter;
+	private final SimpleDateFormat _df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS");
+	private final Date _clientTimestamp;
 	
-	public String getTimestamp() {
-		return _df.format(_timestamp);
+	public String getSessionId() {
+		return _sessionId;
 	}
 	
-	public String getMessage() {
-		return _message;
+	public String getOperation() {
+		return _operation;
 	}
-
-	public TelemetryMessage(String message) {
-		_timestamp = new Date(); 
-		_message = message;
+	
+	public String getParameter() {
+		return _parameter;
 	}
-
+	
+	public String getClientTimestamp() {
+		return _df.format(_clientTimestamp);
+	}
+	
+	public TelemetryMessage(String sessionId, String operation, String parameter) {
+		_sessionId = sessionId;
+		_operation = operation;
+		_parameter = parameter;
+		_clientTimestamp = new Date();
+	}
 }

--- a/src/main/java/com/comodide/telemetry/TelemetryMessage.java
+++ b/src/main/java/com/comodide/telemetry/TelemetryMessage.java
@@ -2,6 +2,7 @@ package com.comodide.telemetry;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.TimeZone;
 
 public class TelemetryMessage {
 	
@@ -31,6 +32,7 @@ public class TelemetryMessage {
 		_sessionId = sessionId;
 		_operation = operation;
 		_parameter = parameter;
+		_df.setTimeZone(TimeZone.getTimeZone("UTC"));
 		_clientTimestamp = new Date();
 	}
 }

--- a/src/main/java/com/comodide/telemetry/TelemetryMessage.java
+++ b/src/main/java/com/comodide/telemetry/TelemetryMessage.java
@@ -1,0 +1,25 @@
+package com.comodide.telemetry;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+public class TelemetryMessage implements ITelemetryMessage {
+	
+	private final SimpleDateFormat _df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+	private final Date _timestamp;
+	private final String _message;
+	
+	public String getTimestamp() {
+		return _df.format(_timestamp);
+	}
+	
+	public String getMessage() {
+		return _message;
+	}
+
+	public TelemetryMessage(String message) {
+		_timestamp = new Date(); 
+		_message = message;
+	}
+
+}

--- a/src/main/java/com/comodide/telemetry/TelemetryUploader.java
+++ b/src/main/java/com/comodide/telemetry/TelemetryUploader.java
@@ -33,7 +33,7 @@ public class TelemetryUploader implements Runnable {
 			String telemetryMessagesAsJson = mapper.writeValueAsString(_messages);
 			log.debug(String.format("Sending telemetry message: '%s'", telemetryMessagesAsJson));
 
-			URL url = new URL("http://localhost:5000/telemetry");
+			URL url = new URL("http://localhost:26003/telemetry");
 			HttpURLConnection con = (HttpURLConnection) url.openConnection();
 			con.setRequestMethod("POST");
 

--- a/src/main/java/com/comodide/telemetry/TelemetryUploader.java
+++ b/src/main/java/com/comodide/telemetry/TelemetryUploader.java
@@ -1,0 +1,82 @@
+package com.comodide.telemetry;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.ProtocolException;
+import java.net.URL;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class TelemetryUploader implements Runnable {
+
+	private static final Logger log = LoggerFactory.getLogger(TelemetryUploader.class);
+
+	private static List<TelemetryMessage> _messages;
+
+	public TelemetryUploader(List<TelemetryMessage> messages) {
+		_messages = messages;
+	}
+
+	@Override
+	public void run() {
+		ObjectMapper mapper = new ObjectMapper();
+		try 
+		{
+			String telemetryMessagesAsJson = mapper.writeValueAsString(_messages);
+			log.debug(String.format("Sending telemetry message: '%s'", telemetryMessagesAsJson));
+
+			URL url = new URL("http://localhost:5000/telemetry");
+			HttpURLConnection con = (HttpURLConnection) url.openConnection();
+			con.setRequestMethod("POST");
+
+			con.setRequestProperty("Content-Type", "application/json; utf-8");
+			con.setRequestProperty("Accept", "text/plain");
+			con.setDoOutput(true);
+
+			try (OutputStream os = con.getOutputStream()) 
+			{
+				byte[] input = telemetryMessagesAsJson.getBytes("utf-8");
+				os.write(input, 0, input.length);
+			}
+
+			try (BufferedReader br = new BufferedReader(new InputStreamReader(con.getInputStream(), "utf-8"))) 
+			{
+				StringBuilder response = new StringBuilder();
+				String responseLine = null;
+				while ((responseLine = br.readLine()) != null) {
+					response.append(responseLine.trim());
+				}
+
+				log.debug(String.format("Submitted telemetry -- got response '%s'", response.toString()));
+				if (response.toString() == "Ok!") {
+					TelemetryAgent.clearLog();
+				}
+			}
+		} 
+		catch (JsonProcessingException e) 
+		{
+			log.error(String.format("JSON processing failed for telemetry list '%s'; exception message: %s", _messages,
+					e.getLocalizedMessage()));
+		} 
+		catch (ProtocolException e) 
+		{
+			log.error(String.format("ProtocolException thrown by TelemetryUploader. Inner exception: '%s'", e.getLocalizedMessage()));
+		} 
+		catch (MalformedURLException e) 
+		{
+			log.error(String.format("MalformedURLException thrown by TelemetryUploader. Inner exception: '%s'", e.getLocalizedMessage()));
+		} 
+		catch (IOException e) 
+		{
+			log.error(String.format("IOException thrown by TelemetryUploader. Inner exception: '%s'", e.getLocalizedMessage()));
+		}
+	}
+}

--- a/src/main/java/com/comodide/telemetry/TelemetryUploader.java
+++ b/src/main/java/com/comodide/telemetry/TelemetryUploader.java
@@ -33,7 +33,7 @@ public class TelemetryUploader implements Runnable {
 			String telemetryMessagesAsJson = mapper.writeValueAsString(_messages);
 			log.debug(String.format("Sending telemetry message: '%s'", telemetryMessagesAsJson));
 
-			URL url = new URL("http://localhost:26003/telemetry");
+			URL url = new URL("https://comodidetelemetry.azurewebsites.net/telemetry");
 			HttpURLConnection con = (HttpURLConnection) url.openConnection();
 			con.setRequestMethod("POST");
 

--- a/src/main/java/com/comodide/views/ConfigurationView.java
+++ b/src/main/java/com/comodide/views/ConfigurationView.java
@@ -23,7 +23,6 @@ import org.slf4j.LoggerFactory;
 import com.comodide.ComodideConfiguration;
 import com.comodide.ComodideConfiguration.EdgeCreationAxiom;
 import com.comodide.telemetry.TelemetryAgent;
-import com.comodide.telemetry.TelemetryMessage;
 
 /**
  * CoModIDE configuration view. Provides an interface through which users may select how CoModIDE should instantiate ontology design patterns
@@ -191,8 +190,8 @@ public class ConfigurationView extends AbstractOWLViewComponent {
 		testButton.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
-				TelemetryMessage message = new TelemetryMessage("This is a test message from CoModIDE");
-				String returnString = TelemetryAgent.SendTelemetry(message);
+				TelemetryAgent.logTestMessage(String.format("%s: %s", testButton.getClass().toString(), testButton.getText()));
+				String returnString = TelemetryAgent.SendTelemetry();
 				JOptionPane.showMessageDialog(topLevelContainer, "Message returned:\n\n" + returnString);
 			}
 		});

--- a/src/main/java/com/comodide/views/ConfigurationView.java
+++ b/src/main/java/com/comodide/views/ConfigurationView.java
@@ -22,6 +22,8 @@ import org.slf4j.LoggerFactory;
 
 import com.comodide.ComodideConfiguration;
 import com.comodide.ComodideConfiguration.EdgeCreationAxiom;
+import com.comodide.telemetry.TelemetryAgent;
+import com.comodide.telemetry.TelemetryMessage;
 
 /**
  * CoModIDE configuration view. Provides an interface through which users may select how CoModIDE should instantiate ontology design patterns
@@ -184,6 +186,17 @@ public class ConfigurationView extends AbstractOWLViewComponent {
 			sendTelemetryButton.setSelected(sendTelemetry);
 			ComodideConfiguration.setSendTelemetry(sendTelemetry);
 		}
+		
+		JButton testButton = new JButton("Send telemetry!");
+		testButton.addActionListener(new ActionListener() {
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				TelemetryMessage message = new TelemetryMessage("This is a test message from CoModIDE");
+				String returnString = TelemetryAgent.SendTelemetry(message);
+				JOptionPane.showMessageDialog(topLevelContainer, "Message returned:\n\n" + returnString);
+			}
+		});
+		this.add(testButton);
 		
 		log.info("Configuration view initialized");
 	}

--- a/src/main/java/com/comodide/views/ConfigurationView.java
+++ b/src/main/java/com/comodide/views/ConfigurationView.java
@@ -191,8 +191,6 @@ public class ConfigurationView extends AbstractOWLViewComponent {
 			@Override
 			public void actionPerformed(ActionEvent e) {
 				TelemetryAgent.logTestMessage(String.format("%s: %s", testButton.getClass().toString(), testButton.getText()));
-				String returnString = TelemetryAgent.SendTelemetry();
-				JOptionPane.showMessageDialog(topLevelContainer, "Message returned:\n\n" + returnString);
 			}
 		});
 		this.add(testButton);

--- a/src/main/java/com/comodide/views/ConfigurationView.java
+++ b/src/main/java/com/comodide/views/ConfigurationView.java
@@ -1,5 +1,6 @@
 package com.comodide.views;
 
+import java.awt.Container;
 import java.awt.Font;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -9,8 +10,10 @@ import java.util.Set;
 
 import javax.swing.BoxLayout;
 import javax.swing.ButtonGroup;
+import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JLabel;
+import javax.swing.JOptionPane;
 import javax.swing.JRadioButton;
 
 import org.protege.editor.owl.ui.view.AbstractOWLViewComponent;
@@ -63,7 +66,7 @@ public class ConfigurationView extends AbstractOWLViewComponent {
 	@Override
 	protected void initialiseOWLView() throws Exception {
 		this.setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
-		
+
 		JLabel entityNamingLabel = new JLabel("Entity naming:");
 		Font f = entityNamingLabel.getFont();
 		entityNamingLabel.setFont(f.deriveFont(f.getStyle() | Font.BOLD));
@@ -146,6 +149,41 @@ public class ConfigurationView extends AbstractOWLViewComponent {
 		edgeDeletionPolicyGroup.add(keepPropertyDeclarationsButton);
 		keepPropertyDeclarationsButton.setSelected(!deletePropertyDeclarationButton.isSelected());
 		this.add(keepPropertyDeclarationsButton);
+		
+		JLabel sendTelemetryLabel = new JLabel("Send usage telemetry:");
+		sendTelemetryLabel.setFont(f.deriveFont(f.getStyle() | Font.BOLD));
+		this.add(sendTelemetryLabel);
+		
+		JCheckBox sendTelemetryButton = new JCheckBox("Send anonymous usage telemetry");
+		sendTelemetryButton.setSelected(ComodideConfiguration.getSendTelemetry());
+		sendTelemetryButton.addItemListener(new ItemListener() {
+			@Override
+			public void itemStateChanged(ItemEvent e) {
+				boolean sendTelemetry = e.getStateChange() == ItemEvent.SELECTED ? true : false;
+				ComodideConfiguration.setSendTelemetry(sendTelemetry);
+			}
+		});
+		this.add(sendTelemetryButton);
+		
+		Container topLevelContainer = this.getTopLevelAncestor();		
+		boolean telemetryPreferenceChecked = ComodideConfiguration.getTelemetryPreferenceChecked();
+		if (!telemetryPreferenceChecked) {
+			int sendTelemetryResponse = JOptionPane.showConfirmDialog(topLevelContainer, 
+					"CoModIDE collects some anonymous usage data, to aid its developer's in understanding which features to \n"
+					+ "work on and how they might be improved. This data includes, e.g., how many clicks it takes the \n"
+					+ "user to find and instantiate a design pattern, how long time it takes to instantiate patterns, \n"
+					+ "what the user edge creation preferences are, etc. By clicking yes below, you accept this this \n"
+					+ "telemetry gathering. If you click no, the feature will be disabled. You can change your preference \n"
+					+ "later on through the CoModIDE configuration view. You can inspect our source code for this and other \n"
+					+ "features through our open GitHub repository, linked from https://comodide.com.", 
+					"Telemetry acceptance", 
+					JOptionPane.YES_NO_OPTION, 
+					JOptionPane.QUESTION_MESSAGE);
+			boolean sendTelemetry = sendTelemetryResponse == JOptionPane.YES_OPTION ? true : false;
+			ComodideConfiguration.setTelemetryPreferenceChecked(true);
+			sendTelemetryButton.setSelected(sendTelemetry);
+			ComodideConfiguration.setSendTelemetry(sendTelemetry);
+		}
 		
 		log.info("Configuration view initialized");
 	}

--- a/src/main/java/com/comodide/views/ConfigurationView.java
+++ b/src/main/java/com/comodide/views/ConfigurationView.java
@@ -10,7 +10,6 @@ import java.util.Set;
 
 import javax.swing.BoxLayout;
 import javax.swing.ButtonGroup;
-import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
@@ -22,7 +21,6 @@ import org.slf4j.LoggerFactory;
 
 import com.comodide.ComodideConfiguration;
 import com.comodide.ComodideConfiguration.EdgeCreationAxiom;
-import com.comodide.telemetry.TelemetryAgent;
 
 /**
  * CoModIDE configuration view. Provides an interface through which users may select how CoModIDE should instantiate ontology design patterns
@@ -185,15 +183,6 @@ public class ConfigurationView extends AbstractOWLViewComponent {
 			sendTelemetryButton.setSelected(sendTelemetry);
 			ComodideConfiguration.setSendTelemetry(sendTelemetry);
 		}
-		
-		JButton testButton = new JButton("Send telemetry!");
-		testButton.addActionListener(new ActionListener() {
-			@Override
-			public void actionPerformed(ActionEvent e) {
-				TelemetryAgent.logTestMessage(String.format("%s: %s", testButton.getClass().toString(), testButton.getText()));
-			}
-		});
-		this.add(testButton);
 		
 		log.info("Configuration view initialized");
 	}

--- a/src/main/java/com/comodide/views/PatternSelectorView.java
+++ b/src/main/java/com/comodide/views/PatternSelectorView.java
@@ -29,6 +29,7 @@ import com.comodide.patterns.PatternCategory;
 import com.comodide.patterns.PatternLibrary;
 import com.comodide.patterns.PatternTable;
 import com.comodide.patterns.PatternTableModel;
+import com.comodide.telemetry.TelemetryAgent;
 
 /**
  * CoModIDE Pattern Selector view. Lists and displays indexed ontology patterns, and provides hooks to initiate pattern instantiation into an ontology.
@@ -70,6 +71,7 @@ public class PatternSelectorView extends AbstractOWLViewComponent {
 			@Override
 			public void actionPerformed(ActionEvent event) {
 				PatternCategory selectedCategory = (PatternCategory)categoryList.getSelectedItem();
+				TelemetryAgent.logLibraryClick(String.format("Category: %s (%s)", selectedCategory.getLabel(), selectedCategory.getIri().toString()));
 				patternsTableModel.update(patternLibrary.getPatternsForCategory(selectedCategory));				
 			}
         });


### PR DESCRIPTION
The pattern library widget calls `TelemetryAgent.logLibraryClick(string parameter)` and `TelemetryAgent.setLastDraggedPatternName(String patternName)` followed by `TelemetryAgent.logPatternDrop()` as needed. These are all static methods. The parameter in the last call indicates what was clicked in the library.

TelemetryAgent stores library clicks in a list until `logPatternDrop()` is called, at which time it starts `TelemetryUploader.run()` on a separate thread to upload all of the gathered logs. If the latter is successful, all log entries are purged from the TelemetryAgent.

None of this happens if `ComodideConfiguration.getSendTelemetry()` (the user preference) is true.