### PR TITLE
Removed manipulation of cell id:s

### DIFF
--- a/src/main/java/com/comodide/editor/changehandlers/LabelChangeHandler.java
+++ b/src/main/java/com/comodide/editor/changehandlers/LabelChangeHandler.java
@@ -61,7 +61,6 @@ public class LabelChangeHandler
 			throw new NameClashException(String.format("[CoModIDE:LabelChangeHandler] An OWL entity with the identifier '%s' already exists; unable to add another one.", newLabel));
 		}
 		
-		cell.setId(newLabel);
 		if (cell.isEdge())
 		{
 			return handleEdgeLabelChange(cell, newLabel);

--- a/src/main/java/com/comodide/editor/changehandlers/UpdateFromOntologyHandler.java
+++ b/src/main/java/com/comodide/editor/changehandlers/UpdateFromOntologyHandler.java
@@ -314,8 +314,8 @@ public class UpdateFromOntologyHandler
 		
 		// This is a simple subclass edge between two nodes, find it and kill it
 		if (superClassExpression.isNamed() && subClassExpression.isNamed()) {
-			ClassCell superClassCell = (ClassCell)schemaDiagram.getCell(superClassExpression.asOWLClass().toString());
-			ClassCell subClassCell = (ClassCell)schemaDiagram.getCell(subClassExpression.asOWLClass().toString());
+			ClassCell superClassCell = (ClassCell)schemaDiagram.getCell(superClassExpression.asOWLClass());
+			ClassCell subClassCell = (ClassCell)schemaDiagram.getCell(subClassExpression.asOWLClass());
 			schemaDiagram.removeSubClassEdge(superClassCell, subClassCell);
 		}
 		// This is potentially a scoped domain/range. Recompute valid edges and 
@@ -348,7 +348,7 @@ public class UpdateFromOntologyHandler
 		// If that pair is not in the set of still valid edges computed above, remove it.
 		// For each still valid edge that is found on the canvas, remove it from the set above
 		// such that at the end of this loop, only un-rendered edges remain in the set.
-		List<mxCell> currentEdges = schemaDiagram.findCellsById(property.toString());
+		List<mxCell> currentEdges = schemaDiagram.findCellsByEntity(property);
 		for (mxCell cell: currentEdges) {
 			if (cell instanceof PropertyEdgeCell) {
 				PropertyEdgeCell currentEdgeCell = (PropertyEdgeCell)cell;
@@ -408,7 +408,7 @@ public class UpdateFromOntologyHandler
 					// cell on the canvas.
 					IRI subjectIRI = (IRI)candidateParentAnnotation.getSubject();
 					double position = value.asLiteral().get().parseDouble();
-					for (mxCell cell: schemaDiagram.findCellsById(String.format("<%s>",subjectIRI.toString()))) {
+					for (mxCell cell: schemaDiagram.findCellsByIri(subjectIRI)) {
 						if (cell instanceof ComodideCell) {
 							mxICell cellToMove;
 							if (cell instanceof PropertyEdgeCell) {

--- a/src/main/java/com/comodide/editor/model/ComodideCell.java
+++ b/src/main/java/com/comodide/editor/model/ComodideCell.java
@@ -20,7 +20,6 @@ public abstract class ComodideCell extends mxCell {
 	
 	public void setEntity(OWLEntity entity) {
 		this.entity = entity;
-		this.id = entity.toString();
 		this.value = shortFormProvider.getShortForm(entity);
 	}
 	


### PR DESCRIPTION
The cell ID:s are mxGraph internals and by using them to store state (specifically stringified IRIs of owl entities) we broke rendering. I've refactored to let mxGraph handle ids w/ our interference. This closes #24