### PR TITLE
Issue#14: Remove neighborhood outline view from canvas

### DIFF
--- a/src/main/java/com/comodide/editor/BasicGraphEditor.java
+++ b/src/main/java/com/comodide/editor/BasicGraphEditor.java
@@ -137,17 +137,10 @@ public class BasicGraphEditor extends JPanel
 		// Creates the library pane that contains the tabs with the palettes
 		libraryPane = new JTabbedPane();
 
-		// Creates the inner split pane that contains the library with the
-		// palettes and the graph outline on the left side of the window
-		JSplitPane inner = new JSplitPane(JSplitPane.VERTICAL_SPLIT, libraryPane, graphOutline);
-		inner.setDividerLocation(320);
-		inner.setResizeWeight(1);
-		inner.setDividerSize(6);
-		inner.setBorder(null);
 
-		// Creates the outer split pane that contains the inner split pane and
+		// Creates the outer split pane that contains the library pane and
 		// the graph component on the right side of the window
-		JSplitPane outer = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, inner, graphComponent);
+		JSplitPane outer = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, libraryPane, graphComponent);
 		outer.setOneTouchExpandable(true);
 		outer.setDividerLocation(230);
 		outer.setDividerSize(6);


### PR DESCRIPTION
Changes: Outline view is removed from canvas
To implement this, inner split pane is removed and library pane is added to outer split pane.
Issue#: 14
Issue link: https://github.com/comodide/CoModIDE/issues/14
