### PR TITLE
Issue #71: Configuration option for unique properties

### DIFF
--- a/src/main/java/com/comodide/ComodideConfiguration.java
+++ b/src/main/java/com/comodide/ComodideConfiguration.java
@@ -35,7 +35,7 @@ public class ComodideConfiguration {
 	    }
 	    
 	    public static List<String> getDefault() {
-	    	ArrayList<String> defaultSelection = new ArrayList<String>();
+	    	ArrayList<String> defaultSelection = new ArrayList<>();
 	    	defaultSelection.add("RDFS_DOMAIN_RANGE");
 	    	return defaultSelection;
 	    }
@@ -48,8 +48,9 @@ public class ComodideConfiguration {
 	private static final String USE_TARGET_NAMESPACE_KEY = "use_target_namespace";
 	private static final String MODULE_METADATA_EXTERNAL_KEY = "module_metadata_external";
 	private static final String DELETE_PROPERTY_DECLARATIONS_KEY = "delete_property_declarations";
-	private static final String SEND_TELEMETRY_KEY = "send_telemetry"; 
-	private static final String TELEMETRY_PREFERENCE_CHECKED_KEY = "telemetry_preference_checked"; 
+	private static final String SEND_TELEMETRY_KEY = "send_telemetry";
+	private static final String TELEMETRY_PREFERENCE_CHECKED_KEY = "telemetry_preference_checked";
+	private static final String UNIQUE_PROPERTIES_CHECKED_KEY = "unique_properties_checked";
 	
 	// Preference manager and set of preferences for the CoModIDE plugin's instantiation configuration
 	private static final PreferencesManager PREFERENCES_MANAGER = PreferencesManager.getInstance();
@@ -155,4 +156,16 @@ public class ComodideConfiguration {
 	public static void setTelemetryPreferenceChecked(Boolean value) {
 		PREFERENCES.putBoolean(TELEMETRY_PREFERENCE_CHECKED_KEY, value);
 	}
+
+	/**
+	 * Whether the user has opted in for the experimental unique properties feature
+	 */
+	public static Boolean getUniquePropertiesChecked() {
+		return PREFERENCES.getBoolean(UNIQUE_PROPERTIES_CHECKED_KEY, false);
+	}
+
+	public static void setUniquePropertiesChecked(Boolean value) {
+		PREFERENCES.putBoolean(UNIQUE_PROPERTIES_CHECKED_KEY, value);
+	}
+
 }

--- a/src/main/java/com/comodide/ComodideConfiguration.java
+++ b/src/main/java/com/comodide/ComodideConfiguration.java
@@ -50,7 +50,7 @@ public class ComodideConfiguration {
 	private static final String DELETE_PROPERTY_DECLARATIONS_KEY = "delete_property_declarations";
 	private static final String SEND_TELEMETRY_KEY = "send_telemetry";
 	private static final String TELEMETRY_PREFERENCE_CHECKED_KEY = "telemetry_preference_checked";
-	private static final String UNIQUE_PROPERTIES_CHECKED_KEY = "unique_properties_checked";
+	private static final String DUPLICATE_PROPERTIES_CHECKED_KEY = "duplicate_properties_checked";
 	
 	// Preference manager and set of preferences for the CoModIDE plugin's instantiation configuration
 	private static final PreferencesManager PREFERENCES_MANAGER = PreferencesManager.getInstance();
@@ -158,14 +158,14 @@ public class ComodideConfiguration {
 	}
 
 	/**
-	 * Whether the user has opted in for the experimental unique properties feature
+	 * Whether the user has opted in for the experimental non-unique properties feature
 	 */
-	public static Boolean getUniquePropertiesChecked() {
-		return PREFERENCES.getBoolean(UNIQUE_PROPERTIES_CHECKED_KEY, false);
+	public static Boolean getDuplicatePropertiesChecked() {
+		return PREFERENCES.getBoolean(DUPLICATE_PROPERTIES_CHECKED_KEY, false);
 	}
 
-	public static void setUniquePropertiesChecked(Boolean value) {
-		PREFERENCES.putBoolean(UNIQUE_PROPERTIES_CHECKED_KEY, value);
+	public static void setDuplicatePropertiesChecked(Boolean value) {
+		PREFERENCES.putBoolean(DUPLICATE_PROPERTIES_CHECKED_KEY, value);
 	}
 
 }

--- a/src/main/java/com/comodide/editor/changehandlers/LabelChangeHandler.java
+++ b/src/main/java/com/comodide/editor/changehandlers/LabelChangeHandler.java
@@ -51,16 +51,22 @@ public class LabelChangeHandler
 		if (!(cell instanceof ComodideCell)) {
 			throw new ComodideException(String.format("[CoModIDE:LabelChangeHandler] The non-CoModIDE cell '%s' was found on the schema diagram. This should never happen.", cell));
 		}
-		
-		// Ensure that the IRI created by this new label is in fact new
-		IRI activeOntologyIri = modelManager.getActiveOntology().getOntologyID().getOntologyIRI().or(IRI.generateDocumentIRI());
-		String entitySeparator = EntityCreationPreferences.getDefaultSeparator();
-		IRI newIRI = IRI.create(activeOntologyIri.toString() + entitySeparator + newLabel);
-		OWLEntityFinder finder = modelManager.getOWLEntityFinder();
-		Set<OWLEntity> existingEntitiesWithName = finder.getEntities(newIRI);
-		if (!existingEntitiesWithName.isEmpty() && ComodideConfiguration.getUniquePropertiesChecked()) {
-			throw new NameClashException(String.format("[CoModIDE:LabelChangeHandler] An OWL entity with the identifier '%s' already exists; unable to add another one.", newLabel));
+
+		// Skip this check if duplicate properties are allowed
+		if (!ComodideConfiguration.getDuplicatePropertiesChecked()) {
+			log.info("[CoModIDE:LabelChangeHandler] Duplicate properties are not permitted.");
+			// Ensure that the IRI created by this new label is in fact new
+			IRI activeOntologyIri = modelManager.getActiveOntology().getOntologyID().getOntologyIRI().or(IRI.generateDocumentIRI());
+			String entitySeparator = EntityCreationPreferences.getDefaultSeparator();
+			IRI newIRI = IRI.create(activeOntologyIri.toString() + entitySeparator + newLabel);
+			OWLEntityFinder finder = modelManager.getOWLEntityFinder();
+			Set<OWLEntity> existingEntitiesWithName = finder.getEntities(newIRI);
+			if (!existingEntitiesWithName.isEmpty()) {
+				log.info("[CoModIDE:LabelChangeHandler] Duplicate property detected.");
+				throw new NameClashException(String.format("[CoModIDE:LabelChangeHandler] An OWL entity with the identifier '%s' already exists; unable to add another one.", newLabel));
+			}
 		}
+		else log.info("[CoModIDE:LabelChangeHandler] Duplicate properties are permitted.");
 		
 		if (cell.isEdge())
 		{

--- a/src/main/java/com/comodide/editor/changehandlers/LabelChangeHandler.java
+++ b/src/main/java/com/comodide/editor/changehandlers/LabelChangeHandler.java
@@ -3,6 +3,7 @@ package com.comodide.editor.changehandlers;
 import java.util.List;
 import java.util.Set;
 
+import com.comodide.ComodideConfiguration;
 import org.protege.editor.owl.model.OWLModelManager;
 import org.protege.editor.owl.model.entity.EntityCreationPreferences;
 import org.protege.editor.owl.model.find.OWLEntityFinder;
@@ -57,7 +58,7 @@ public class LabelChangeHandler
 		IRI newIRI = IRI.create(activeOntologyIri.toString() + entitySeparator + newLabel);
 		OWLEntityFinder finder = modelManager.getOWLEntityFinder();
 		Set<OWLEntity> existingEntitiesWithName = finder.getEntities(newIRI);
-		if (existingEntitiesWithName.size() > 0) {
+		if (!existingEntitiesWithName.isEmpty() && ComodideConfiguration.getUniquePropertiesChecked()) {
 			throw new NameClashException(String.format("[CoModIDE:LabelChangeHandler] An OWL entity with the identifier '%s' already exists; unable to add another one.", newLabel));
 		}
 		

--- a/src/main/java/com/comodide/views/ConfigurationView.java
+++ b/src/main/java/com/comodide/views/ConfigurationView.java
@@ -189,9 +189,9 @@ public class ConfigurationView extends AbstractOWLViewComponent {
 		this.add(uniquePropertiesLabel);
 
 		JCheckBox uniquePropertiesButton = new JCheckBox("Allow Duplicate Properties (Experimental Feature)");
-		uniquePropertiesButton.setSelected(ComodideConfiguration.getUniquePropertiesChecked());
+		uniquePropertiesButton.setSelected(ComodideConfiguration.getDuplicatePropertiesChecked());
 		uniquePropertiesButton.addItemListener(e ->
-				ComodideConfiguration.setUniquePropertiesChecked(e.getStateChange() == ItemEvent.DESELECTED)
+				ComodideConfiguration.setDuplicatePropertiesChecked(e.getStateChange() == ItemEvent.SELECTED)
         );
 		this.add(uniquePropertiesButton);
 		

--- a/src/main/java/com/comodide/views/ConfigurationView.java
+++ b/src/main/java/com/comodide/views/ConfigurationView.java
@@ -178,11 +178,22 @@ public class ConfigurationView extends AbstractOWLViewComponent {
 					"Telemetry acceptance", 
 					JOptionPane.YES_NO_OPTION, 
 					JOptionPane.QUESTION_MESSAGE);
-			boolean sendTelemetry = sendTelemetryResponse == JOptionPane.YES_OPTION ? true : false;
+			boolean sendTelemetry = sendTelemetryResponse == JOptionPane.YES_OPTION;
 			ComodideConfiguration.setTelemetryPreferenceChecked(true);
 			sendTelemetryButton.setSelected(sendTelemetry);
 			ComodideConfiguration.setSendTelemetry(sendTelemetry);
 		}
+
+		JLabel uniquePropertiesLabel = new JLabel("Property Uniqueness:");
+		uniquePropertiesLabel.setFont(f.deriveFont(f.getStyle() | Font.BOLD));
+		this.add(uniquePropertiesLabel);
+
+		JCheckBox uniquePropertiesButton = new JCheckBox("Allow Duplicate Properties (Experimental Feature)");
+		uniquePropertiesButton.setSelected(ComodideConfiguration.getUniquePropertiesChecked());
+		uniquePropertiesButton.addItemListener(e ->
+				ComodideConfiguration.setUniquePropertiesChecked(e.getStateChange() == ItemEvent.DESELECTED)
+        );
+		this.add(uniquePropertiesButton);
 		
 		log.info("Configuration view initialized");
 	}


### PR DESCRIPTION
Added a checkbox to the ConfigurationView that allows the user to enable an experimental feature to allow the creation of multiple properties with the same name.