### PR TITLE
Updated Pull Request: Issue#79: Edge Inspector View shows cellID instead of Label

### DIFF
--- a/src/main/java/com/comodide/views/EdgeInspectorView.java
+++ b/src/main/java/com/comodide/views/EdgeInspectorView.java
@@ -139,7 +139,7 @@ public class EdgeInspectorView extends AbstractOWLViewComponent implements Comod
 				// Track the current selected cell
 				this.currentSelectedCell = (PropertyEdgeCell) payload;
 				// Change the title of the view
-				this.edgeLabel.setText(this.currentSelectedCell.getId());
+				this.edgeLabel.setText((String) this.currentSelectedCell.getValue());
 				// Bring up the axioms
 				this.changeVisibility("edge");
 				// Set dynamic checking for each checkbox


### PR DESCRIPTION
Changes: Edge label will now be displayed in edge inspector view in place of CellId
To implement this minor change has been done in EdgeInspectorView where value of current cell is extracted in place of Id as edge label
Issue#: 79
Issue link: https://github.com/comodide/CoModIDE/issues/79